### PR TITLE
Fixing the gcc linker order

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -8,8 +8,8 @@ LIB=libyawrap
 LIB_NAME=libyawrap.so
 OBJ_NAME=yawrap.o
 
-SHARED_OPTS=-shared -o $(LIB_NAME) $(OBJ_NAME) -Wl,-Bstatic $(STATIC_LIBS) \
--Wl,-Bdynamic $(LIBS)
+SHARED_OPTS=-shared -Wl,-Bstatic $(STATIC_LIBS) \
+-Wl,-Bdynamic $(LIBS) -o $(LIB_NAME) $(OBJ_NAME)
 
 PWD=`pwd`
 


### PR DESCRIPTION
Hi,

I got the below errors during the build.

```
# make
(cd src; make all)
make[1]: Entering directory '/home/jpereira/Devel/github-jpereira/lua-ffi-yara.git/src'
gcc -shared -o libyawrap.so yawrap.o -Wl,-Bstatic -lyara -Wl,-Bdynamic -lpthread -lcrypto
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/6/../../../x86_64-linux-gnu/libyara.a(object.o): relocation R_X86_64_PC32 against symbol `stderr@@GLIBC_2.2.5' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: Bad value
collect2: error: ld returned 1 exit status
Makefile:19: recipe for target 'libyawrap' failed
make[1]: *** [libyawrap] Error 1
make[1]: Leaving directory '/home/jpereira/Devel/github-jpereira/lua-ffi-yara.git/src'
Makefile:2: recipe for target 'all' failed
make: *** [all] Error 2
#
``` 

My setup is:

```
# lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 16.10
Release:	16.10
Codename:	yakkety
# dpkg -s gcc | grep Version
Version: 4:6.1.1-1ubuntu2
#
```

you can see the fix into this PR.